### PR TITLE
:sparkles: feat: 두 번째 환율 계산 기능 구현

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -12,4 +12,16 @@ module.exports = {
       '@router': path.resolve(__dirname, 'src/router'),
     },
   },
+  jest: {
+    configure: {
+      moduleNameMapper: {
+        '^\\@components/(.*)$': '<rootDir>/src/components/$1',
+        '^\\@pages/(.*)$': '<rootDir>/src/pages/$1',
+        '^\\@api/(.*)$': '<rootDir>/src/api/$1',
+        '^\\@utils/(.*)$': '<rootDir>/src/utils/$1',
+        '^\\@styles/(.*)$': '<rootDir>/src/styles/$1',
+        '^\\@router/(.*)$': '<rootDir>/src/router/$1',
+      },
+    },
+  },
 };

--- a/public/index.html
+++ b/public/index.html
@@ -1,21 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <!-- <link rel="manifest" href="%PUBLIC_URL%/manifest.json" /> -->
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,12 +22,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>React App</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -39,5 +38,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import SecondCalcPage from '@pages/SecondCalcPage/SecondCalcPage';
 
 const App = () => {
-  return <></>;
+  return (
+    <>
+      <SecondCalcPage />
+    </>
+  );
 };
 
 export default App;

--- a/src/components/CurrentCurrency/CurrentCurrency.jsx
+++ b/src/components/CurrentCurrency/CurrentCurrency.jsx
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { RATE_LIST, MONTHS } from '@utils/constants';
+import { request } from '@api/api';
+
+const CurrentCurrency = ({ source }) => {
+  const [selected, setSelected] = useState('CAD');
+  const [date, setDate] = useState();
+  const [currency, setCurrency] = useState();
+  const getApi = async () => {
+    try {
+      const { timestamp, quotes } = await request();
+      let date = new Date(timestamp * 1000); // UNIX 시간을 JS 시간으로 변경
+      console.log(
+        timestamp,
+        date,
+        `${date.getFullYear()}-${MONTHS[date.getMonth()]}-${date.getDate()}`,
+      ); // TODO: utils로 빼기
+      setDate(
+        `${date.getFullYear()}-${MONTHS[date.getMonth()]}-${date.getDate()}`,
+      );
+      /* NOTE: 문제 찾았음
+        timestamp가 갱신되지 않고 있었습니다
+        아마 어제 저 서버 구동 끝난 시간에 종료된거 아닌가 싶습니다
+        그러면 기준일이 어제 시간으로 나오는 게 맞는 것 같아요
+        FAQ: How often are exchange rates refreshed?
+        Spot exchange rate data is collected within the 60-second market window.
+        Depending on your Subscription Plan, quotes are refreshed every day (Free Plan)
+      */
+      // 2022-Jan-01
+      // TODO: setCurrency(utils)
+    } catch (e) {
+      console.log(e);
+      // TODO: 에러 핸들링
+    }
+  };
+
+  useEffect(() => {
+    getApi();
+  }, [selected]);
+
+  return (
+    <Wrap>
+      <CurrencyBtnWrap>
+        {RATE_LIST.map((data, idx) => (
+          <div key={idx}>
+            {source !== data.country && (
+              <CurrencyBtn>{data.country}</CurrencyBtn>
+            )}
+          </div>
+        ))}
+      </CurrencyBtnWrap>
+      <div>{selected}</div>
+      <div>
+        <p>{`${selected} 2,000 !FIXME`}</p>
+        <p>기준일 : </p>
+        <p>{date}</p>
+      </div>
+    </Wrap>
+  );
+};
+
+const Wrap = styled.article`
+  border: 3px solid black;
+`;
+
+const CurrencyBtnWrap = styled.div`
+  display: flex;
+`;
+
+const CurrencyBtn = styled.button`
+  background-color: #fff;
+  border-bottom: none;
+`;
+
+export default CurrentCurrency;

--- a/src/components/CurrentCurrency/CurrentCurrency.jsx
+++ b/src/components/CurrentCurrency/CurrentCurrency.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { RATE_LIST, MONTHS } from '@utils/constants';
+import { RATE_LIST } from '@utils/constants';
+import { convertTimestampToDate } from '@utils/date';
 import { request } from '@api/api';
 
 const CurrentCurrency = ({ source }) => {
@@ -10,29 +11,16 @@ const CurrentCurrency = ({ source }) => {
   const getApi = async () => {
     try {
       const { timestamp, quotes } = await request();
-      let date = new Date(timestamp * 1000); // UNIX 시간을 JS 시간으로 변경
-      console.log(
-        timestamp,
-        date,
-        `${date.getFullYear()}-${MONTHS[date.getMonth()]}-${date.getDate()}`,
-      ); // TODO: utils로 빼기
-      setDate(
-        `${date.getFullYear()}-${MONTHS[date.getMonth()]}-${date.getDate()}`,
-      );
-      /* NOTE: 문제 찾았음
-        timestamp가 갱신되지 않고 있었습니다
-        아마 어제 저 서버 구동 끝난 시간에 종료된거 아닌가 싶습니다
-        그러면 기준일이 어제 시간으로 나오는 게 맞는 것 같아요
-        FAQ: How often are exchange rates refreshed?
-        Spot exchange rate data is collected within the 60-second market window.
-        Depending on your Subscription Plan, quotes are refreshed every day (Free Plan)
-      */
-      // 2022-Jan-01
+      setDate(convertTimestampToDate(timestamp));
       // TODO: setCurrency(utils)
     } catch (e) {
       console.log(e);
       // TODO: 에러 핸들링
     }
+  };
+
+  const handleCurrencyClick = (e) => {
+    console.log(e.target.innerText);
   };
 
   useEffect(() => {
@@ -43,11 +31,16 @@ const CurrentCurrency = ({ source }) => {
     <Wrap>
       <CurrencyBtnWrap>
         {RATE_LIST.map((data, idx) => (
-          <div key={idx}>
+          <React.Fragment key={idx}>
             {source !== data.country && (
-              <CurrencyBtn>{data.country}</CurrencyBtn>
+              <CurrencyBtn
+                selected={selected === data.country}
+                onClick={handleCurrencyClick}
+              >
+                {data.country}
+              </CurrencyBtn>
             )}
-          </div>
+          </React.Fragment>
         ))}
       </CurrencyBtnWrap>
       <div>{selected}</div>
@@ -69,8 +62,12 @@ const CurrencyBtnWrap = styled.div`
 `;
 
 const CurrencyBtn = styled.button`
-  background-color: #fff;
-  border-bottom: none;
+  background-color: red;
+  border-right: 3px solid black;
+  &:last-child {
+    border-right: none;
+  }
+  border-bottom: ${(props) => (props.selected ? 'none' : '3px solid black')}; ;
 `;
 
 export default CurrentCurrency;

--- a/src/components/CurrentCurrency/CurrentCurrency.jsx
+++ b/src/components/CurrentCurrency/CurrentCurrency.jsx
@@ -73,6 +73,7 @@ const Wrap = styled.article`
   justify-content: space-between;
   width: 100%;
   border: 3px solid black;
+  border-radius: 0.5rem;
 `;
 
 const CurrencyBtnWrap = styled.div`
@@ -87,15 +88,22 @@ const CurrencyBtn = styled.button`
     props.selected ? '3px solid transparent' : '3px solid black'};
   font-size: 1rem;
   font-weight: ${(props) => (props.selected ? 'bold' : 'normal')};
-  color: ${(props) => (props.selected ? 'black' : 'gray')};
+  color: ${(props) => (props.selected ? '#1b6139' : '#fff')};
+  background-color: ${(props) => (props.selected ? '#f4e8d1' : '#73737a')};
 
   &:last-child {
     border-right: none;
+  }
+
+  &:hover {
+    filter: ${(props) =>
+      props.selected ? 'brightness(1)' : 'brightness(1.2)'};
   }
 `;
 
 const CurrencyResult = styled.div`
   padding: 1.5rem;
+  background-color: #f4e8d1;
 
   h2 {
     display: inline-block;
@@ -104,11 +112,12 @@ const CurrencyResult = styled.div`
     margin-bottom: 1rem;
     font-size: 1.3rem;
     font-weight: bold;
+    color: #1b6139;
   }
 
   h3 {
-    margin-bottom: 0.5rem;
-    font-size: 1.3rem;
+    margin-bottom: 0.3rem;
+    font-size: 1.2rem;
     font-weight: bold;
   }
 

--- a/src/components/CurrentCurrency/CurrentCurrency.jsx
+++ b/src/components/CurrentCurrency/CurrentCurrency.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { RATE_LIST } from '@utils/constants';
 import { convertTimestampToDate } from '@utils/date';
@@ -9,7 +9,8 @@ const CurrentCurrency = ({ source, inputValue }) => {
   const [selected, setSelected] = useState('CAD');
   const [date, setDate] = useState();
   const [currency, setCurrency] = useState('');
-  const getApi = async () => {
+
+  const getApi = useCallback(async () => {
     try {
       const { timestamp, quotes } = await request();
       setDate(convertTimestampToDate(timestamp));
@@ -21,9 +22,9 @@ const CurrentCurrency = ({ source, inputValue }) => {
         ),
       );
     } catch (e) {
-      console.log(e);
+      alert(`API에서 오류가 발생했습니다: ${e.message}`);
     }
-  };
+  }, [source, selected, inputValue]);
 
   const handleCurrencyClick = (e) => {
     setSelected(e.target.innerText);
@@ -36,7 +37,7 @@ const CurrentCurrency = ({ source, inputValue }) => {
       );
     }
     getApi();
-  }, [source, selected, inputValue]);
+  }, [source, selected, inputValue, getApi]);
 
   return (
     <Wrap>

--- a/src/components/CurrentCurrency/CurrentCurrency.jsx
+++ b/src/components/CurrentCurrency/CurrentCurrency.jsx
@@ -20,12 +20,17 @@ const CurrentCurrency = ({ source }) => {
   };
 
   const handleCurrencyClick = (e) => {
-    console.log(e.target.innerText);
+    setSelected(e.target.innerText);
   };
 
   useEffect(() => {
+    if (source === selected) {
+      setSelected(
+        RATE_LIST.filter((rate) => rate.country !== source)[0].country,
+      );
+    }
     getApi();
-  }, [selected]);
+  }, [source, selected]);
 
   return (
     <Wrap>
@@ -43,17 +48,20 @@ const CurrentCurrency = ({ source }) => {
           </React.Fragment>
         ))}
       </CurrencyBtnWrap>
-      <div>{selected}</div>
-      <div>
-        <p>{`${selected} 2,000 !FIXME`}</p>
-        <p>기준일 : </p>
+      <CurrencyResult>
+        <h2>{`${selected} 2,000.00 !FIXME`}</h2>
+        <h3>기준일</h3>
         <p>{date}</p>
-      </div>
+      </CurrencyResult>
     </Wrap>
   );
 };
 
 const Wrap = styled.article`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
   border: 3px solid black;
 `;
 
@@ -62,12 +70,37 @@ const CurrencyBtnWrap = styled.div`
 `;
 
 const CurrencyBtn = styled.button`
-  background-color: red;
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  font-size: 1rem;
+  font-weight: ${(props) => (props.selected ? 'bold' : 'normal')};
+  color: ${(props) => (props.selected ? 'black' : 'gray')};
   border-right: 3px solid black;
+  border-bottom: ${(props) =>
+    props.selected ? '3px solid transparent' : '3px solid black'};
   &:last-child {
     border-right: none;
   }
-  border-bottom: ${(props) => (props.selected ? 'none' : '3px solid black')}; ;
+`;
+
+const CurrencyResult = styled.div`
+  padding: 1.5rem;
+
+  h2 {
+    font-size: 1.3rem;
+    font-weight: bold;
+    margin-bottom: 1rem;
+  }
+
+  h3 {
+    font-size: 1.3rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    font-size: 1rem;
+  }
 `;
 
 export default CurrentCurrency;

--- a/src/components/CurrentCurrency/CurrentCurrency.jsx
+++ b/src/components/CurrentCurrency/CurrentCurrency.jsx
@@ -2,20 +2,26 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { RATE_LIST } from '@utils/constants';
 import { convertTimestampToDate } from '@utils/date';
+import { convertCurrency } from '@utils/currency';
 import { request } from '@api/api';
 
-const CurrentCurrency = ({ source }) => {
+const CurrentCurrency = ({ source, inputValue }) => {
   const [selected, setSelected] = useState('CAD');
   const [date, setDate] = useState();
-  const [currency, setCurrency] = useState();
+  const [currency, setCurrency] = useState('');
   const getApi = async () => {
     try {
       const { timestamp, quotes } = await request();
       setDate(convertTimestampToDate(timestamp));
-      // TODO: setCurrency(utils)
+      setCurrency(
+        convertCurrency(
+          quotes[`USD${source}`],
+          quotes[`USD${selected}`],
+          inputValue.split(',').join(''),
+        ),
+      );
     } catch (e) {
       console.log(e);
-      // TODO: 에러 핸들링
     }
   };
 
@@ -30,7 +36,7 @@ const CurrentCurrency = ({ source }) => {
       );
     }
     getApi();
-  }, [source, selected]);
+  }, [source, selected, inputValue]);
 
   return (
     <Wrap>
@@ -49,7 +55,10 @@ const CurrentCurrency = ({ source }) => {
         ))}
       </CurrencyBtnWrap>
       <CurrencyResult>
-        <h2>{`${selected} 2,000.00 !FIXME`}</h2>
+        <h2>
+          <span>{selected}</span>
+          <span>{currency}</span>
+        </h2>
         <h3>기준일</h3>
         <p>{date}</p>
       </CurrencyResult>
@@ -72,12 +81,13 @@ const CurrencyBtnWrap = styled.div`
 const CurrencyBtn = styled.button`
   width: 100%;
   padding: 0.3rem 0.5rem;
-  font-size: 1rem;
-  font-weight: ${(props) => (props.selected ? 'bold' : 'normal')};
-  color: ${(props) => (props.selected ? 'black' : 'gray')};
   border-right: 3px solid black;
   border-bottom: ${(props) =>
     props.selected ? '3px solid transparent' : '3px solid black'};
+  font-size: 1rem;
+  font-weight: ${(props) => (props.selected ? 'bold' : 'normal')};
+  color: ${(props) => (props.selected ? 'black' : 'gray')};
+
   &:last-child {
     border-right: none;
   }
@@ -87,15 +97,18 @@ const CurrencyResult = styled.div`
   padding: 1.5rem;
 
   h2 {
+    display: inline-block;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1rem;
     font-size: 1.3rem;
     font-weight: bold;
-    margin-bottom: 1rem;
   }
 
   h3 {
+    margin-bottom: 0.5rem;
     font-size: 1.3rem;
     font-weight: bold;
-    margin-bottom: 0.5rem;
   }
 
   p {

--- a/src/components/SelectCurrency/SelectCurrency.jsx
+++ b/src/components/SelectCurrency/SelectCurrency.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
 import { RATE_LIST } from '@utils/constants';
+import { inputNumberFormat } from '@utils/currency';
 
 const SelectCurrency = ({ setSource, setInputValue, inputValue }) => {
   const handleChange = (e) => {
-    //자식에서 부모 state를 바꿔도 될까?
     setSource(e.target.value);
   };
 
   const handleInput = (e) => {
-    const currentInput = e.target.value;
-    if (!/^[0-9]*$/.test(currentInput)) {
-      return;
-    }
-
-    setInputValue(e.target.value);
+    setInputValue(inputNumberFormat(e.target.value));
   };
 
   return (

--- a/src/components/SelectCurrency/SelectCurrency.jsx
+++ b/src/components/SelectCurrency/SelectCurrency.jsx
@@ -32,15 +32,24 @@ const Wrap = styled.div`
 
   input {
     padding: 0.3rem 0.5rem;
-    font-size: 1rem;
-    border: 3px solid black;
     margin-right: 1rem;
+    border: 3px solid black;
+    border-radius: 0.3rem;
+    font-size: 1rem;
+    background-color: #f4e8d1;
   }
 
   select {
     padding: 0.3rem 0.5rem;
-    font-size: 1rem;
     border: 3px solid black;
+    border-radius: 0.3rem;
+    font-size: 1rem;
+    background-color: #f4e8d1;
+    cursor: pointer;
+
+    &:hover {
+      filter: brightness(1.1);
+    }
   }
 `;
 

--- a/src/components/SelectCurrency/SelectCurrency.jsx
+++ b/src/components/SelectCurrency/SelectCurrency.jsx
@@ -1,17 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { RATE_LIST } from '@utils/constants';
-import { inputNumberFormat } from '@utils/currency';
 
-const SelectCurrency = ({ setSource, setInputValue, inputValue }) => {
-  const handleChange = (e) => {
-    setSource(e.target.value);
-  };
-
-  const handleInput = (e) => {
-    setInputValue(inputNumberFormat(e.target.value));
-  };
-
+const SelectCurrency = ({ handleInput, inputValue, handleOptionChange }) => {
   return (
     <Wrap>
       <input
@@ -20,7 +11,7 @@ const SelectCurrency = ({ setSource, setInputValue, inputValue }) => {
         placeholder="금액을 입력하세요."
         value={inputValue}
       />
-      <select name="currency" onChange={handleChange}>
+      <select name="currency" onChange={handleOptionChange}>
         {RATE_LIST.map((data, idx) => {
           return (
             <option value={data.country} key={idx}>

--- a/src/components/SelectCurrency/SelectCurrency.jsx
+++ b/src/components/SelectCurrency/SelectCurrency.jsx
@@ -39,7 +39,23 @@ const SelectCurrency = ({ setSource, setInputValue, inputValue }) => {
 };
 
 const Wrap = styled.div`
-  margin-bottom: 2rem;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin-bottom: 1rem;
+
+  input {
+    padding: 0.3rem 0.5rem;
+    font-size: 1rem;
+    border: 3px solid black;
+    margin-right: 1rem;
+  }
+
+  select {
+    padding: 0.3rem 0.5rem;
+    font-size: 1rem;
+    border: 3px solid black;
+  }
 `;
 
 export default SelectCurrency;

--- a/src/components/SelectCurrency/SelectCurrency.jsx
+++ b/src/components/SelectCurrency/SelectCurrency.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components';
+import { RATE_LIST } from '@utils/constants';
+
+const SelectCurrency = ({ setSource, setInputValue, inputValue }) => {
+  const handleChange = (e) => {
+    //자식에서 부모 state를 바꿔도 될까?
+    setSource(e.target.value);
+  };
+
+  const handleInput = (e) => {
+    const currentInput = e.target.value;
+    if (!/^[0-9]*$/.test(currentInput)) {
+      return;
+    }
+
+    setInputValue(e.target.value);
+  };
+
+  return (
+    <Wrap>
+      <input
+        type="text"
+        onChange={handleInput}
+        placeholder="금액을 입력하세요."
+        value={inputValue}
+      />
+      <select name="currency" onChange={handleChange}>
+        {RATE_LIST.map((data, idx) => {
+          return (
+            <option value={data.country} key={idx}>
+              {data.country}
+            </option>
+          );
+        })}
+      </select>
+    </Wrap>
+  );
+};
+
+const Wrap = styled.div`
+  margin-bottom: 2rem;
+`;
+
+export default SelectCurrency;

--- a/src/pages/SecondCalcPage/SecondCalcPage.jsx
+++ b/src/pages/SecondCalcPage/SecondCalcPage.jsx
@@ -25,23 +25,22 @@ const SecondCalcPage = () => {
 
 const Container = styled.section`
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 25rem;
-  width: 20rem;
-  border: 1px solid red;
-  background-color: aqua;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 `;
 
 const Wrap = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
+  justify-content: center;
   align-items: center;
-  height: 20rem;
-  width: 15rem;
-  background-color: beige;
+  padding: 10px;
+  border: 3px solid black;
 `;
 
 export default SecondCalcPage;

--- a/src/pages/SecondCalcPage/SecondCalcPage.jsx
+++ b/src/pages/SecondCalcPage/SecondCalcPage.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useState } from 'react';
+import CurrentCurrency from '@components/CurrentCurrency/CurrentCurrency';
+import SelectCurrency from '@components/SelectCurrency/SelectCurrency';
+
+const SecondCalcPage = () => {
+  const [source, setSource] = useState('USD');
+  const [inputValue, setInputValue] = useState('');
+  // 로직은 컴포넌트 분리하면서 생각
+  return (
+    <Container>
+      <Wrap>
+        <h1 className="sr-only">환율 계산기</h1>
+        <SelectCurrency
+          inputValue={inputValue}
+          setInputValue={setInputValue}
+          setSource={setSource}
+        />
+        <CurrentCurrency source={source} />
+      </Wrap>
+    </Container>
+  );
+};
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 25rem;
+  width: 20rem;
+  border: 1px solid red;
+  background-color: aqua;
+`;
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  height: 20rem;
+  width: 15rem;
+  background-color: beige;
+`;
+
+export default SecondCalcPage;

--- a/src/pages/SecondCalcPage/SecondCalcPage.jsx
+++ b/src/pages/SecondCalcPage/SecondCalcPage.jsx
@@ -7,7 +7,7 @@ import SelectCurrency from '@components/SelectCurrency/SelectCurrency';
 const SecondCalcPage = () => {
   const [source, setSource] = useState('USD');
   const [inputValue, setInputValue] = useState('');
-  // 로직은 컴포넌트 분리하면서 생각
+
   return (
     <Container>
       <Wrap>
@@ -17,7 +17,7 @@ const SecondCalcPage = () => {
           setInputValue={setInputValue}
           setSource={setSource}
         />
-        <CurrentCurrency source={source} />
+        <CurrentCurrency source={source} inputValue={inputValue} />
       </Wrap>
     </Container>
   );

--- a/src/pages/SecondCalcPage/SecondCalcPage.jsx
+++ b/src/pages/SecondCalcPage/SecondCalcPage.jsx
@@ -3,10 +3,19 @@ import styled from 'styled-components';
 import { useState } from 'react';
 import CurrentCurrency from '@components/CurrentCurrency/CurrentCurrency';
 import SelectCurrency from '@components/SelectCurrency/SelectCurrency';
+import { inputNumberFormat } from '@utils/currency';
 
 const SecondCalcPage = () => {
   const [source, setSource] = useState('USD');
   const [inputValue, setInputValue] = useState('');
+
+  const handleOptionChange = (e) => {
+    setSource(e.target.value);
+  };
+
+  const handleInput = (e) => {
+    setInputValue(inputNumberFormat(e.target.value));
+  };
 
   return (
     <Container>
@@ -14,8 +23,8 @@ const SecondCalcPage = () => {
         <h1 className="sr-only">환율 계산기</h1>
         <SelectCurrency
           inputValue={inputValue}
-          setInputValue={setInputValue}
-          setSource={setSource}
+          handleOptionChange={handleOptionChange}
+          handleInput={handleInput}
         />
         <CurrentCurrency source={source} inputValue={inputValue} />
       </Wrap>

--- a/src/pages/SecondCalcPage/SecondCalcPage.jsx
+++ b/src/pages/SecondCalcPage/SecondCalcPage.jsx
@@ -41,6 +41,7 @@ const Container = styled.section`
   left: 0;
   right: 0;
   bottom: 0;
+  background-color: #f2f2f2;
 `;
 
 const Wrap = styled.div`
@@ -48,8 +49,10 @@ const Wrap = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 10px;
-  border: 3px solid black;
+  padding: 1rem;
+  border: 8px solid #686868;
+  border-radius: 0.5rem;
+  background-color: #f5aea8;
 `;
 
 export default SecondCalcPage;

--- a/src/pages/SecondCalcPage/index.jsx
+++ b/src/pages/SecondCalcPage/index.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export const index = () => {
-  return <div></div>;
-};

--- a/src/styles/globals.jsx
+++ b/src/styles/globals.jsx
@@ -130,6 +130,16 @@ ul {
   padding: 0;
 }
 
+button {
+      background: inherit;
+      border: none;
+      box-shadow: none;
+      border-radius: 0;
+      padding: 0;
+      overflow: visible;
+      cursor: pointer;
+    }
+
 * {
   box-sizing: border-box;
 }

--- a/src/test/utils/currency.test.js
+++ b/src/test/utils/currency.test.js
@@ -1,0 +1,68 @@
+import {
+  convertCurrency,
+  convertComma,
+  removeComma,
+  inputNumberFormat,
+} from '@utils/currency';
+
+describe('Function convertComma', () => {
+  it('takes numbers under 1,000', () => {
+    expect(convertComma('123')).toEqual('123');
+    expect(convertComma('456')).toEqual('456');
+    expect(convertComma('789')).toEqual('789');
+  });
+
+  it('takes numbers over 1,000 under 1,000,000', () => {
+    expect(convertComma('1000')).toEqual('1,000');
+    expect(convertComma('1234')).toEqual('1,234');
+    expect(convertComma('6789')).toEqual('6,789');
+  });
+
+  it('takes numbers over 1,000,000 under 1,000,000,000', () => {
+    expect(convertComma('1000000')).toEqual('1,000,000');
+    expect(convertComma('1234567')).toEqual('1,234,567');
+    expect(convertComma('6789876')).toEqual('6,789,876');
+  });
+});
+
+describe('Function removeComma', () => {
+  it('takes numbers under 1,000', () => {
+    expect(removeComma('123')).toEqual('123');
+    expect(removeComma('456')).toEqual('456');
+    expect(removeComma('789')).toEqual('789');
+  });
+
+  it('takes numbers over 1,000 under 1,000,000', () => {
+    expect(removeComma('1,000')).toEqual('1000');
+    expect(removeComma('1,234')).toEqual('1234');
+    expect(removeComma('6,789')).toEqual('6789');
+  });
+
+  it('takes numbers over 1,000,000 under 1,000,000,000', () => {
+    expect(removeComma('1,000,000')).toEqual('1000000');
+    expect(removeComma('1,234,567')).toEqual('1234567');
+    expect(removeComma('6,789,876')).toEqual('6789876');
+  });
+});
+
+describe('Function inputNumberFormat', () => {
+  it('takes numbers over 1,000 under 1,000,000', () => {
+    expect(inputNumberFormat('1234')).toEqual('1,234');
+    expect(inputNumberFormat('4567')).toEqual('4,567');
+    expect(inputNumberFormat('9999')).toEqual('9,999');
+  });
+
+  it('takes numbers over 1,000,000 under 1,000,000,000', () => {
+    expect(inputNumberFormat('1000000')).toEqual('1,000,000');
+    expect(inputNumberFormat('1234567')).toEqual('1,234,567');
+    expect(inputNumberFormat('6789876')).toEqual('6,789,876');
+  });
+});
+
+describe('Function convertCurrency', () => {
+  it('change USD to CAD', () => {
+    expect(convertCurrency('3', '9', 3)).toEqual('9.00');
+    expect(convertCurrency('4', '16', 3)).toEqual('12.00');
+    expect(convertCurrency('7', '49', 5)).toEqual('35.00');
+  });
+});

--- a/src/test/utils/date.test.js
+++ b/src/test/utils/date.test.js
@@ -1,0 +1,18 @@
+import { convertTimestampToDate } from '@utils/date';
+
+describe('Function convertTimeStampToDate', () => {
+  it('takes some date and converts to date string', () => {
+    expect(convertTimestampToDate(Date.UTC(2022, 0, 1) / 1000)).toEqual(
+      '2022-Jan-01',
+    );
+    expect(convertTimestampToDate(Date.UTC(1997, 0, 31) / 1000)).toEqual(
+      '1997-Jan-31',
+    );
+    expect(convertTimestampToDate(Date.UTC(1789, 11, 25) / 1000)).toEqual(
+      '1789-Dec-25',
+    );
+    expect(convertTimestampToDate(Date.UTC(1999, 3, 4) / 1000)).toEqual(
+      '1999-Apr-04',
+    );
+  });
+});

--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -3,3 +3,27 @@ const { REACT_APP_API_KEY } = process.env;
 export const API_POINT = 'http://www.apilayer.net/api/live';
 
 export const DEFAULT_URL = API_POINT + '?access_key=' + REACT_APP_API_KEY;
+
+export const RATE_LIST = [
+  { country: 'USD' },
+  { country: 'CAD' },
+  { country: 'KRW' },
+  { country: 'HKD' },
+  { country: 'JPY' },
+  { country: 'CNY' },
+];
+
+export const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];

--- a/src/utils/currency.jsx
+++ b/src/utils/currency.jsx
@@ -1,5 +1,8 @@
 export const convertCurrency = (source, selected, inputValue) => {
-  const result = ((selected / source) * inputValue).toFixed(2);
+  const result = (
+    (Number(selected) / Number(source)) *
+    Number(inputValue)
+  ).toFixed(2);
   return convertComma(result);
 };
 
@@ -13,12 +16,4 @@ export const removeComma = (str) => {
 
 export const inputNumberFormat = (value) => {
   return convertComma(removeComma(value));
-};
-
-export const onlyNumber = (str) => {
-  return String(str).replace(/(\d)(?=(?:\d{3})+(?!\d))/g, '$1');
-};
-
-export const inputOnlyNumberFormat = (value) => {
-  return onlyNumber(removeComma(value));
 };

--- a/src/utils/currency.jsx
+++ b/src/utils/currency.jsx
@@ -1,0 +1,24 @@
+export const convertCurrency = (source, selected, inputValue) => {
+  const result = ((selected / source) * inputValue).toFixed(2);
+  return convertComma(result);
+};
+
+export const convertComma = (str) => {
+  return String(str).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};
+
+export const removeComma = (str) => {
+  return String(str).replace(/[^\d]+/g, '');
+};
+
+export const inputNumberFormat = (value) => {
+  return convertComma(removeComma(value));
+};
+
+export const onlyNumber = (str) => {
+  return String(str).replace(/(\d)(?=(?:\d{3})+(?!\d))/g, '$1');
+};
+
+export const inputOnlyNumberFormat = (value) => {
+  return onlyNumber(removeComma(value));
+};

--- a/src/utils/date.jsx
+++ b/src/utils/date.jsx
@@ -2,5 +2,8 @@ import { MONTHS } from '@utils/constants';
 
 export const convertTimestampToDate = (timestamp) => {
   const date = new Date(timestamp * 1000); // UNIX 시간을 JS 시간으로 변환
-  return `${date.getFullYear()}-${MONTHS[date.getMonth()]}-${date.getDate()}`;
+  const year = date.getFullYear();
+  const month = MONTHS[date.getMonth()];
+  const day = date.getDate();
+  return `${year}-${month}-${day < 10 ? '0' + String(day) : day}`;
 };

--- a/src/utils/date.jsx
+++ b/src/utils/date.jsx
@@ -1,0 +1,6 @@
+import { MONTHS } from '@utils/constants';
+
+export const convertTimestampToDate = (timestamp) => {
+  const date = new Date(timestamp * 1000); // UNIX 시간을 JS 시간으로 변환
+  return `${date.getFullYear()}-${MONTHS[date.getMonth()]}-${date.getDate()}`;
+};


### PR DESCRIPTION
# 프로젝트 제목 
두 번째 환율 계산 기능

by. @hyo-choi @Junghoon-P 
Discord와 VSCode Liveshare를 이용해 페어 프로그래밍 방식으로 공동 작업했습니다.

## 세부 사항
```bash
src
├── api # 변경 없음
├── components
│   ├── CurrentCurrency # 계산기 아래 tab 부분 컴포넌트
│   └── SelectCurrency   # 계산기 위 input+dropdown 부분 컴포넌트
├── pages
│   ├── FirstCalcPage # 변경 없음
│   └── SecondCalcPage # 두 번째 환율 계산기 page
├── router # 변경 없음
├── styles # button reset style 추가
├── test
│   └── utils  # 해당 브랜치 utils 함수에 대한 unit test 추가
└── utils       # 필요한 utils 추가
```
- 두 번째 환율 계산 기능의 요구사항에 맞춰 구현했습니다.
  - [x] 숫자만 입력할 수 있고, 단위마다 ',' 표시를 붙여주는 input ([링크](https://github.com/OnBoarding-Park-is-best/week1-calculator/blob/scdCalc/mainUI/src/pages/SecondCalcPage/SecondCalcPage.jsx#L16))
  - [x] USD, CAD, KRW,  HKD, JPY, CNY를 포함하는 dropdown ([constants](https://github.com/OnBoarding-Park-is-best/week1-calculator/blob/scdCalc/mainUI/src/utils/constants.jsx#L7), [dropdown](https://github.com/OnBoarding-Park-is-best/week1-calculator/blob/scdCalc/mainUI/src/components/SelectCurrency/SelectCurrency.jsx#L15))
  - [x] 드롭다운 메뉴에서 선택된 통화가 아래 tab란에 표시되지 않도록 하는 기능 ([링크](https://github.com/OnBoarding-Park-is-best/week1-calculator/blob/scdCalc/mainUI/src/components/CurrentCurrency/CurrentCurrency.jsx#L45))
  - [x] 드롭다운 메뉴를 이용한 통화 변경시 변경될 환율과 기준일 정보 동기화 ([링크](https://github.com/OnBoarding-Park-is-best/week1-calculator/blob/scdCalc/mainUI/src/components/CurrentCurrency/CurrentCurrency.jsx#L13))
  - [x] 기준일 날짜 formatting ([링크](https://github.com/OnBoarding-Park-is-best/week1-calculator/blob/scdCalc/mainUI/src/utils/date.jsx#L3), [unit test](https://github.com/OnBoarding-Park-is-best/week1-calculator/blob/scdCalc/mainUI/src/test/utils/date.test.js)) 
- jest를 이용해 utils 함수의 unit test를 구현했습니다. ([링크](https://github.com/OnBoarding-Park-is-best/week1-calculator/tree/scdCalc/mainUI/src/test/utils))
  unit test 결과는 `yarn test` command로 확인하실 수 있습니다.

## 기타 질문 및 특이 사항
### API 관련
- API response의 timestamp를 new Date(timestamp)로 변환했을 때 이상한 날짜가 나오는 issue가 있었습니다.
  API에서 UNIX timestamp(s 기준)을 사용하기 때문에 JS의 timestamp(ms 기준)로 사용하려면 timestamp * 1000을 해주어야 했습니다.
- API response의 timestamp가 현재 시간과 맞지 않는 경우가 있어 구현이 잘못되었다 생각했습니다.
  그런데 API FAQ-Data & Sources-How often are exchange rates refreshed? 항목을 보니 Free Plan은 quotes가 하루에 한 번만 갱신된다고 되어 있었습니다. 따라서 날짜가 맞지 않아도 어제 날짜라면 정상 동작한 것으로 판단하고 그대로 진행했습니다.
### React practice 관련
- useState로 받아온 setter를 자식 컴포넌트에 props로 내려준 경우가 있었는데, 흔히 사용하는 방식이 아니라고 하여 부모 컴포넌트에서 handler를 만들어 내려주는 방식으로 변경하였습니다. ([관련 글 링크](https://www.reddit.com/r/learnreactjs/comments/m99nbz/is_it_a_good_practice_to_pass_setstate_of_one/))
### unit test 관련
- jest와 craco를 동시에 사용할 때 jest의 `*.test.js` 파일에서 절대경로 import가 되지 않는 issue가 있었습니다.
  [이 글](https://cloudless.blog/post/React%20Typescript%20Jest%20%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C%20craco%EB%A5%BC%20%EC%9D%B4%EC%9A%A9%ED%95%9C%20path%20alias%20%EC%84%A4%EC%A0%95)을 참고하여 해결했고, [craco.config.js 파일](https://github.com/OnBoarding-Park-is-best/week1-calculator/blob/scdCalc/mainUI/craco.config.js)에 변경사항이 반영되어 있습니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
